### PR TITLE
Working towards better bind/listen support for alternative stream protoc...

### DIFF
--- a/server/lib/Server.cpp
+++ b/server/lib/Server.cpp
@@ -44,6 +44,7 @@ Server::Server(int port, unsigned int max_clients,
                                    + 1)                                  /* 1 for NUL terminator */
     char port_str[DIGIT_STRING_LENGTH(port)];
 
+    sprintf(port_str, "%d", port);
     if (getaddrinfo(host_str, port_str, &(struct addrinfo){ .ai_family = PF_UNSPEC, .ai_socktype = SOCK_STREAM, .ai_flags = AI_PASSIVE }, &m_tcp_address) != 0) {
         m_logger.log("[ERR]  Failed to resolve local stream interface: {}",
                      strerror(errno));

--- a/server/lib/Server.hpp
+++ b/server/lib/Server.hpp
@@ -78,10 +78,18 @@ private:
 
     unsigned int m_max_clients;
 
+#   define IPV4_ONLY
+#   ifndef IPV4_ONLY
+    std::vector<Socket> m_tcp_socket;
+    struct sockaddr_in *m_tcp_address;
+    std::vector<Socket> m_udp_socket;
+    struct sockaddr_in *m_udp_address;
+#   else
     Socket m_tcp_socket;
     struct sockaddr_in m_tcp_address;
     Socket m_udp_socket;
     struct sockaddr_in m_udp_address;
+#   endif
 
     std::vector<Client> m_clients;
     common::Logger m_logger;


### PR DESCRIPTION
Working towards better bind/listen support for alternative stream protocols (eg. UNIX sockets, IPV4, IPV6, etc).

Currently, this feature is disabled by include guards (IPV4_ONLY, defined in Server.hpp) because it's incomplete and will break the build otherwise.