### PR TITLE
Use Python for server networking

### DIFF
--- a/client/Game.hpp
+++ b/client/Game.hpp
@@ -24,13 +24,13 @@
 /// The Zordzman client.
 namespace client {
 
-class Client {
+class Game {
 public:
-    Client(Config const & cfg, HUD hud);
-    ~Client();
+    Game(Config const & cfg, HUD hud);
+    ~Game();
 
     /// Get the active game instance
-    static Client & get();
+    static Game & get();
 
     /// The client's mainloop.
     void exec();
@@ -57,8 +57,8 @@ public:
     void addMessage(std::string message);
 
 private:
-    Client(const Client &) = delete;
-    Client & operator=(const Client &) = delete;
+    Game(const Game &) = delete;
+    Game & operator=(const Game &) = delete;
     bool m_running;
 
     sys::SysContext m_system;
@@ -85,7 +85,7 @@ public:
     ResourceManager m_resources;
 
 private:
-    static Client * m_instance;
+    static Game * m_instance;
     Config const & m_cfg;
     std::string m_map_hash;
     std::string m_map_name;

--- a/client/audioPlayer.cpp
+++ b/client/audioPlayer.cpp
@@ -3,7 +3,7 @@
 #include "ResourceManager.hpp"
 #include "common/resources/MusicResource.hpp"
 #include "format.h"
-#include "Client.hpp"
+#include "Game.hpp"
 
 #include <iterator>
 
@@ -13,7 +13,7 @@ namespace client {
 namespace audio {
 
 void playMusic(std::string name) {
-    ResourceManager * manager = &Client::get().m_resources;
+    ResourceManager * manager = &Game::get().m_resources;
 
     MusicResource music = manager->m_music[name];
 
@@ -27,7 +27,7 @@ void playMusic(std::string name) {
 }
 
 void playSound(std::string name) {
-    ResourceManager * manager = &Client::get().m_resources;
+    ResourceManager * manager = &Game::get().m_resources;
 
     SoundResource sound = manager->m_sounds[name];
 

--- a/client/gfx/drawingOperations.cpp
+++ b/client/gfx/drawingOperations.cpp
@@ -1,6 +1,6 @@
 #include "gfx/drawingOperations.hpp"
 
-#include "Client.hpp"
+#include "Game.hpp"
 #include "ResourceManager.hpp"
 
 #include "common/resources/SpriteResource.hpp"
@@ -30,7 +30,7 @@ void drawSprite(std::string name, float x, float y, float w, float h,
         return;
     }
 
-    ResourceManager * manager = &Client::get().m_resources;
+    ResourceManager * manager = &Game::get().m_resources;
     SpriteResource sprite = manager->m_sprites[name];
 
     if (sprite.m_path.empty()) {
@@ -141,7 +141,7 @@ void drawText(std::string font, std::string const & text, int x, int y, int w,
         return;
     }
 
-    ResourceManager * manager = &Client::get().m_resources;
+    ResourceManager * manager = &Game::get().m_resources;
     FontResource fontresource = manager->m_fonts[font];
 
     if (!fontresource.m_valid) {

--- a/client/level/Level.cpp
+++ b/client/level/Level.cpp
@@ -3,7 +3,7 @@
 #include "common/entity/components/character.hpp"
 #include "common/entity/components/render.hpp"
 #include "common/entity/components/position.hpp"
-#include "Client.hpp"
+#include "Game.hpp"
 #include "level/tiles/Tile.hpp"
 #include "format.h"
 #include "common/util/stream.hpp"
@@ -109,7 +109,7 @@ void Level::setTileAt(int x, int y, byte tile) {
 
 void Level::render() const {
     using namespace drawingOperations;
-    auto & window = Client::get().getWindow();
+    auto & window = Game::get().getWindow();
 
     // Borders for the renders.
     int minX = (int)(0 / 32);

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -1,4 +1,4 @@
-#include "Client.hpp"
+#include "Game.hpp"
 
 #include <stdexcept>
 #include <clocale>
@@ -34,7 +34,7 @@ int main(int argc, char * argv[]) {
             cfg.port = std::stoi(argv[2]);
         }
         // Initialize the game.
-        Client game(cfg, hud);
+        Game game(cfg, hud);
         // Start the game loop.
         game.exec();
     } catch (std::exception const & except) {


### PR DESCRIPTION
We are currently using Python for the client's networking as Python will allow an abstraction over simply using Berkeley/Winsock sockets, which as a result makes supporting Windows far easier.

This pull request will also convert the server's networking to use Python.